### PR TITLE
Code Cleanup & Replace with some known structs in FFCS

### DIFF
--- a/NoKillPlugin/NoKillPlugin.csproj
+++ b/NoKillPlugin/NoKillPlugin.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
 	<NoWarn>IDE0003</NoWarn>
 	<NoWarn>CA1416</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
@@ -31,6 +32,10 @@
     <Reference Include="ImGui.NET">
       <HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="FFXIVClientStructs">
+      <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 

--- a/NoKillPlugin/Plugin.cs
+++ b/NoKillPlugin/Plugin.cs
@@ -2,145 +2,82 @@
 using Dalamud.Plugin;
 using Dalamud.Hooking;
 using System;
-using System.Runtime.InteropServices;
-using Dalamud.Game;
 using Dalamud.IoC;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
-namespace NoKillPlugin
+namespace NoKillPlugin;
+
+public class NoKillPlugin : IDalamudPlugin
 {
-    public class NoKillPlugin : IDalamudPlugin
+    public string Name => "No Kill Plugin";
+
+    internal static Configuration Config;
+    private         PluginUi      Gui { get; set; }
+
+    [PluginService] internal static IDalamudPluginInterface PluginInterface { get; private set; }
+    [PluginService] internal static ICondition              Conditions      { get; private set; }
+    [PluginService] internal static ICommandManager         CommandManager  { get; private set; }
+    [PluginService] internal static IClientState            ClientState     { get; private set; }
+    [PluginService] internal static IGameInteropProvider    HookProvider    { get; private set; }
+    [PluginService] internal static IPluginLog              PluginLog       { get; private set; }
+
+    private unsafe delegate bool LobbyErrorHandlerDelegate(AtkMessageBoxManager* manager, nint a2, AtkValue* values);
+    private readonly Hook<LobbyErrorHandlerDelegate> LobbyErrorHandlerHook;
+    
+    public unsafe NoKillPlugin()
     {
-        public string Name => "No Kill Plugin";
+        Config = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
 
-        internal static Configuration Config;
-        public PluginUi Gui { get; private set; }
-
-        [PluginService] internal static IDalamudPluginInterface PluginInterface { get; private set; }
-        [PluginService] internal static ICondition Conditions { get; private set; }
-        [PluginService] internal static ISigScanner SigScanner { get; private set; }
-        [PluginService] internal static ICommandManager CommandManager { get; private set; }
-        [PluginService] internal static IGameNetwork GameNetwork { get; private set; }
-        [PluginService] internal static IChatGui ChatGui { get; private set; }
-        [PluginService] internal static IDataManager DataManager { get; private set; }
-        [PluginService] internal static IClientState ClientState { get; private set; }
-        [PluginService] internal static IGameInteropProvider HookProvider { get; private set; }
-        [PluginService] internal static IPluginLog PluginLog { get; private set; }
-
-
-        internal IntPtr StartHandler;
-        internal IntPtr LoginHandler;
-        internal IntPtr LobbyErrorHandler;
-        private delegate Int64 StartHandlerDelegate(Int64 a1, Int64 a2);
-        private delegate Int64 LoginHandlerDelegate(Int64 a1, Int64 a2);
-        private delegate char LobbyErrorHandlerDelegate(Int64 a1, Int64 a2, Int64 a3);
-        //private Hook<StartHandlerDelegate> StartHandlerHook;
-        //private Hook<LoginHandlerDelegate> LoginHandlerHook;
-        private Hook<LobbyErrorHandlerDelegate> LobbyErrorHandlerHook;
-        public NoKillPlugin()
+        Gui = new PluginUi(this);
+        
+        CommandManager.AddHandler("/nokill", new CommandInfo(CommandHandler)
         {
-            this.LobbyErrorHandler = SigScanner.ScanText("40 53 48 83 EC 30 48 8B D9 49 8B C8 E8 ?? ?? ?? ?? 8B D0");
-            this.LobbyErrorHandlerHook = HookProvider.HookFromAddress<LobbyErrorHandlerDelegate>(
-                LobbyErrorHandler, 
-                new LobbyErrorHandlerDelegate(LobbyErrorHandlerDetour)
-            );
-            /*
-            this.StartHandler = SigScanner.ScanText("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 66 44 89 65 ??");
-            this.StartHandlerHook = HookProvider.HookFromAddress<StartHandlerDelegate>(
-                StartHandler,
-                new StartHandlerDelegate(StartHandlerDetour)
-            );
-            this.LoginHandler = SigScanner.ScanText("40 55 53 56 57 41 54 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 8B B1 ?? ?? ?? ??");
-            this.LoginHandlerHook = HookProvider.HookFromAddress<LoginHandlerDelegate>(
-                LoginHandler,
-                new LoginHandlerDelegate(LoginHandlerDetour)
-            );
-            */
+            HelpMessage = "/nokill - open the no kill plugin panel."
+        });
+        
+        LobbyErrorHandlerHook =
+            HookProvider.HookFromSignature<LobbyErrorHandlerDelegate>(
+                "40 53 48 83 EC 30 48 8B D9 49 8B C8 E8 ?? ?? ?? ?? 8B D0",
+                LobbyErrorHandlerDetour);
+        LobbyErrorHandlerHook.Enable();
+    }
 
-            Config = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
-            // Config.Initialize(PluginInterface);
+    private void CommandHandler(string command, string arguments)
+    {
+        var args = arguments.Trim().Replace("\"", string.Empty);
+        if(!string.IsNullOrEmpty(args) && !args.Equals("config", StringComparison.OrdinalIgnoreCase)) return;
+        
+        Gui.ConfigWindow.Visible = !Gui.ConfigWindow.Visible;
+    }
 
-            CommandManager.AddHandler("/nokill", new CommandInfo(CommandHandler)
-            {
-                HelpMessage = "/nokill - open the no kill plugin panel."
-            });
-
-            Gui = new PluginUi(this);
-
-            this.LobbyErrorHandlerHook.Enable();
-            //this.StartHandlerHook.Enable();
-            //this.LoginHandlerHook.Enable();
-        }
-        public void CommandHandler(string command, string arguments)
+    private unsafe bool LobbyErrorHandlerDetour(AtkMessageBoxManager* manager, nint a2, AtkValue* values)
+    {
+        var errorCase = values->UInt;
+        
+        PluginLog.Debug($"LobbyErrorHandler Error Case: {errorCase}");
+        if (errorCase > 0)
         {
-            var args = arguments.Trim().Replace("\"", string.Empty);
-
-            if (string.IsNullOrEmpty(args) || args.Equals("config", StringComparison.OrdinalIgnoreCase))
+            Gui.ConfigWindow.Visible = true;
+            if (errorCase == 0x332C && Config.SkipAuthError) // Auth failed
             {
-                Gui.ConfigWindow.Visible = !Gui.ConfigWindow.Visible;
-                return;
+                PluginLog.Debug("Skip Auth Error");
+            }
+            else
+            {
+                values->UInt = 0x3E80; // server connection lost; 0x3390: maintenance
             }
         }
-        /*
-        private Int64 StartHandlerDetour(Int64 a1, Int64 a2)
-        {
-            var a1_88 = (UInt16)Marshal.ReadInt16(new IntPtr(a1 + 88));
-            var a1_4472 = Marshal.ReadInt32(new IntPtr(a1 + 4472));
-            PluginLog.Debug($"Start a1_4472:{a1_4472}");
-            if (a1_4472 != 0 && Config.QueueMode)
-            {
-                Marshal.WriteInt32(new IntPtr(a1 + 4472), 0);
-                PluginLog.Debug($"a1_4472: {a1_4472} => 0");
-            }
-            return this.StartHandlerHook.Original(a1, a2);
-        }
-        private Int64 LoginHandlerDetour(Int64 a1, Int64 a2)
-        {
-            var a1_4321 = Marshal.ReadByte(new IntPtr(a1 + 4321));
-            PluginLog.Debug($"Login a1_4321:{a1_4321}");
-            if (a1_4321 != 0 && Config.QueueMode)
-            {
-                Marshal.WriteByte(new IntPtr(a1 + 4321), 0);
-                PluginLog.Debug($"a1_4321: {a1_4321} => 0");
-            }
-            return this.LoginHandlerHook.Original(a1, a2);
-        }
-        */
+        
+        PluginLog.Debug($"After LobbyErrorHandler Error Case: {values->UInt}");
+        return LobbyErrorHandlerHook.Original(manager, a2, values);
+    }
 
-
-        private char LobbyErrorHandlerDetour(Int64 a1, Int64 a2, Int64 a3)
-        {
-            IntPtr p3 = new IntPtr(a3);
-            var t1 = Marshal.ReadByte(p3);
-            var v4 = ((t1 & 0xF) > 0) ? (uint)Marshal.ReadInt32(p3 + 8) : 0;
-            UInt16 v4_16 = (UInt16)(v4);
-            PluginLog.Debug($"LobbyErrorHandler a1:{a1} a2:{a2} a3:{a3} t1:{t1} v4:{v4_16}");
-            if (v4 > 0)
-            {
-                this.Gui.ConfigWindow.Visible = true;
-                if (v4_16 == 0x332C && Config.SkipAuthError) // Auth failed
-                {
-                    PluginLog.Debug($"Skip Auth Error");
-                }
-                else
-                {
-                    Marshal.WriteInt64(p3 + 8, 0x3E80); // server connection lost
-                    // 0x3390: maintenance
-                    v4 = ((t1 & 0xF) > 0) ? (uint)Marshal.ReadInt32(p3 + 8) : 0;
-                    v4_16 = (UInt16)(v4);
-                }
-            }
-            PluginLog.Debug($"After LobbyErrorHandler a1:{a1} a2:{a2} a3:{a3} t1:{t1} v4:{v4_16}");
-            return this.LobbyErrorHandlerHook.Original(a1, a2, a3);
-        }
-
-        public void Dispose()
-        {
-            this.LobbyErrorHandlerHook.Dispose();
-            //this.StartHandlerHook.Dispose();
-            //this.LoginHandlerHook.Dispose();
-            CommandManager.RemoveHandler("/nokill");
-            Gui?.Dispose();
-        }
+    public void Dispose()
+    {
+        CommandManager.RemoveHandler("/nokill");
+        Gui?.Dispose();
+        
+        LobbyErrorHandlerHook.Dispose();
     }
 }


### PR DESCRIPTION
code cleanup and replace with some known structs in FFCS so make things easier to read and understand.

IntPtr a1 → AtkMessageBoxManager* manager
IntPtr a2 → nint a2 (actually not used in the original game func)
IntPtr a3 → AtkValue* values

If the type of `AtkValue* values` is not `UInt`, then its value will remain 0, so I just delete the ternary for the type check.